### PR TITLE
fix: code after an empty line should be handled and be monospace in code blocks

### DIFF
--- a/app/cutemarkdownhighlighter.cpp
+++ b/app/cutemarkdownhighlighter.cpp
@@ -64,7 +64,7 @@ void CuteMarkdownHighlighter::setYamlHeaderSupportEnabled(bool enabled)
 
 void CuteMarkdownHighlighter::highlightBlock(const QString &textBlock)
 {
-    if (textBlock.isEmpty()) {
+    if (textBlock.isEmpty() && !MarkdownHighlighter::isCodeBlock(previousBlockState())) {
         return;
     }
 

--- a/app/cutemarkdownhighlighter.cpp
+++ b/app/cutemarkdownhighlighter.cpp
@@ -64,10 +64,6 @@ void CuteMarkdownHighlighter::setYamlHeaderSupportEnabled(bool enabled)
 
 void CuteMarkdownHighlighter::highlightBlock(const QString &textBlock)
 {
-    if (false && textBlock.isEmpty() && !MarkdownHighlighter::isCodeBlock(previousBlockState())) {
-        return;
-    }
-
     MarkdownHighlighter::highlightBlock(textBlock);
 
 //    // check spelling of passed text block

--- a/app/cutemarkdownhighlighter.cpp
+++ b/app/cutemarkdownhighlighter.cpp
@@ -64,7 +64,7 @@ void CuteMarkdownHighlighter::setYamlHeaderSupportEnabled(bool enabled)
 
 void CuteMarkdownHighlighter::highlightBlock(const QString &textBlock)
 {
-    if (textBlock.isEmpty() && !MarkdownHighlighter::isCodeBlock(previousBlockState())) {
+    if (false && textBlock.isEmpty() && !MarkdownHighlighter::isCodeBlock(previousBlockState())) {
         return;
     }
 


### PR DESCRIPTION
````
```
aaa

bbb
```
````
is currently not correctly hightlighted in Markdown editor; `bbb` is not monospace.

This PR fixes the issue.