### PR TITLE
fix: CSS should respect HTML font family and size in settings

### DIFF
--- a/app/styles/byword-dark.css
+++ b/app/styles/byword-dark.css
@@ -1,8 +1,8 @@
 body {
      	/* SANS-SERIF */	
-		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif !important;
+		font-family: sans-serif !important;
 		-webkit-font-smoothing: antialiased !important;
-  font-size: 16px;
+  font-size: 1em;
   line-height: 1.4;
   padding-top: 10px;
   padding-bottom: 10px;

--- a/app/styles/clearness-dark.css
+++ b/app/styles/clearness-dark.css
@@ -35,7 +35,7 @@ hr {
 }
 pre > code {
 /*  font-size: .9em;*/
-  font-family: Consolas, Inconsolata, Courier, monospace;
+  font-family: monospace;
 }
 blockquote {
   border-left: 4px solid #121319;

--- a/app/styles/clearness.css
+++ b/app/styles/clearness.css
@@ -42,7 +42,7 @@ hr {
 }
 pre > code {
 /*  font-size: .9em;*/
-  font-family: "Source Code Pro", Monokai, Consolas, Inconsolata,  Courier, monospace;
+  font-family: monospace;
 }
 blockquote {
   padding: 0 15px;

--- a/app/styles/github.css
+++ b/app/styles/github.css
@@ -1,7 +1,7 @@
 body {
-  font-family: Helvetica, arial, sans-serif;
-  font-size: 14px;
-  line-height: 1.6;
+  font-family: sans-serif;
+  font-size: 1em;
+  line-height: 1.3;
   padding-top: 10px;
   padding-bottom: 10px;
   background-color: white;
@@ -57,26 +57,26 @@ h6 tt, h6 code {
   font-size: inherit; }
 
 h1 {
-  font-size: 28px;
+  font-size: 2em;
   color: black; }
 
 h2 {
-  font-size: 24px;
+  font-size: 1.8em;
   border-bottom: 1px solid #cccccc;
   color: black; }
 
 h3 {
-  font-size: 18px; }
+  font-size: 1.28em; }
 
 h4 {
-  font-size: 16px; }
+  font-size: 1.14em; }
 
 h5 {
-  font-size: 14px; }
+  font-size: 1em; }
 
 h6 {
   color: #777777;
-  font-size: 14px; }
+  font-size: 1em; }
 
 p, blockquote, ul, ol, dl, li, table, pre {
   margin: 15px 0; }
@@ -122,7 +122,7 @@ ul :first-child, ol :first-child {
 dl {
   padding: 0; }
   dl dt {
-    font-size: 14px;
+    font-size: 1em;
     font-weight: bold;
     font-style: italic;
     padding: 0;
@@ -255,8 +255,8 @@ pre code {
 .highlight pre {
   background-color: #f8f8f8;
   border: 1px solid #cccccc;
-  font-size: 13px;
-  line-height: 19px;
+  font-size: 0.95em;
+  line-height: 1.5;
   overflow: auto;
   padding: 6px 10px;
   border-radius: 3px; }
@@ -264,8 +264,8 @@ pre code {
 pre {
   background-color: #f8f8f8;
   border: 1px solid #cccccc;
-  font-size: 13px;
-  line-height: 19px;
+  font-size: 0.95em;
+  line-height: 1.25;
   overflow: auto;
   padding: 6px 10px;
   border-radius: 3px; }
@@ -292,13 +292,13 @@ kbd {
     border-color: #dddddd #cccccc #cccccc #dddddd;
     border-image: none;
     border-style: solid;
-    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-family: sans-serif;
     line-height: 10px;
     padding: 1px 4px;
 }
 
 * {
-	-webkit-print-color-adjust: exact;
+        -webkit-print-color-adjust: exact;
 }
 @media screen and (min-width: 914px) {
     body {
@@ -307,10 +307,10 @@ kbd {
     }
 }
 @media print {
-	table, pre {
-		page-break-inside: avoid;
-	}
-	pre {
-		word-wrap: break-word;
-	}
+        table, pre {
+                page-break-inside: avoid;
+        }
+        pre {
+                word-wrap: break-word;
+        }
 }

--- a/app/styles/markdown.css
+++ b/app/styles/markdown.css
@@ -20,37 +20,42 @@
  */
 body{
     margin: 0 auto;
-    font-family: Georgia, Palatino, serif;
+    font-family: serif;
     color: #444444;
     line-height: 1;
-    max-width: 960px;
+    /* max-width: 960px; */
     padding: 30px;
 }
 h1, h2, h3, h4 {
     color: #111111;
-    font-weight: 400;
+    font-weight: bold;
 }
 h1, h2, h3, h4, h5, p {
-    margin-bottom: 24px;
+    margin-bottom: 0.6em;
     padding: 0;
 }
 h1 {
-    font-size: 48px;
+    font-size: 3em;
 }
 h2 {
-    font-size: 36px;
-    /* The bottom margin is small. It's designed to be used with gray meta text
+    font-size: 2.6em;
+    /* Note: you cant use single quotation marks in CSS in Qt, or the
+     * stylesheet will fail to load! */
+     
+     
+    /* The bottom margin is small. Its designed to be used with gray meta text
      * below a post title. */
-    margin: 24px 0 6px;
+    /* 👆 No we dont want that now */
+    /* margin: 24px 0px 6px 0px; */
 }
 h3 {
-    font-size: 24px;
+    font-size: 1.6em;
 }
 h4 {
-    font-size: 21px;
+    font-size: 1.4em;
 }
 h5 {
-    font-size: 18px;
+    font-size: 1.2em;
 }
 a {
     color: #0099ff;
@@ -66,29 +71,29 @@ a:visited {
     color: purple;
 }
 ul, ol {
-    padding: 0;
-    margin: 0;
+    /* padding: 0;
+    margin: 0; */
 }
 li {
-    line-height: 24px;
+    line-height: 1.32;
 }
 li ul, li ul {
-    margin-left: 24px;
+    margin-left: 1.32;
 }
 p, ul, ol {
-    font-size: 16px;
-    line-height: 24px;
-    max-width: 540px;
+    font-size: 1em;
+    line-height: 1.32;
+    /* max-width: 540px; */
 }
 pre {
     padding: 0px 24px;
-    max-width: 800px;
+    /* max-width: 800px; */
     white-space: pre-wrap;
 }
 code {
-    font-family: Consolas, Monaco, Andale Mono, monospace;
+    font-family: monospace;
     line-height: 1.5;
-/*    font-size: 13px;*/
+/*    font-size: 0.9em;*/
 }
 aside {
     display: block;
@@ -99,7 +104,7 @@ blockquote {
     border-left:.5em solid #eee;
     padding: 0 2em;
     margin-left:0;
-    max-width: 476px;
+    /* max-width: 476px; */
 }
 blockquote  cite {
     font-size:14px;
@@ -107,15 +112,15 @@ blockquote  cite {
     color:#bfbfbf;
 }
 blockquote cite:before {
-    content: '\2014 \00A0';
+    content: "\2014 \00A0";
 }
 
-blockquote p {  
+blockquote p {
     color: #666;
-    max-width: 460px;
+    /* max-width: 460px; */
 }
 hr {
-    width: 540px;
+    /* width: 540px; */
     text-align: left;
     margin: 0 auto 0 0;
     color: #999;
@@ -170,8 +175,8 @@ label,
 input,
 select,
 textarea {
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 13px;
+  font-family: sans-serif;
+  font-size: 0.9em;
   font-weight: normal;
   line-height: normal;
   margin-bottom: 18px;
@@ -185,9 +190,9 @@ input[type=password],
 textarea,
 select {
   display: inline-block;
-  width: 210px;
+  /* width: 210px; */
   padding: 4px;
-  font-size: 13px;
+  font-size: 0.9em;
   font-weight: normal;
   line-height: 18px;
   height: 18px;
@@ -236,8 +241,8 @@ input[type=text]:focus, input[type=password]:focus, textarea:focus {
 button {
   display: inline-block;
   padding: 4px 14px;
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 13px;
+  font-family: sans-serif;
+  font-size: 0.9em;
   line-height: 18px;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;

--- a/app/styles/solarized-dark.css
+++ b/app/styles/solarized-dark.css
@@ -19,9 +19,9 @@ img {
   vertical-align: baseline;
 }
 html * {
-  font-family: "ff-din-web-pro-1", "ff-din-web-pro-2", sans-serif;
-  font-size: 16px;
-  line-height: 19.2px;
+  font-family: sans-serif;
+  font-size: 1em;
+  line-height: 1.2;
   color-profile: sRGB;
 }
 body {
@@ -29,7 +29,7 @@ body {
 }
 p {
   font-weight: lighter;
-  margin-bottom: 20px;
+  margin-bottom: 0.8em;
 }
 strong {
   font-weight: bold;
@@ -37,16 +37,16 @@ strong {
 ol,
 ul {
   margin-left: 2em;
-  margin-bottom: 20px;
+  margin-bottom: 0.6em;
 }
 ul ul,
 ol ol,
 ul ol,
 ol ul {
-  margin-top: 10px;
+  margin-top: 0.3em;
 }
 li {
-  margin-bottom: 10px;
+  margin-bottom: 0.3em;
 }
 h1,
 h2,
@@ -56,35 +56,35 @@ h5,
 h6 {
   font-weight: lighter;
   text-transform: capitalize;
-  margin-top: 40px;
-  margin-bottom: 20px;
+  margin-top: 0.7em;
+  margin-bottom: 0.35em;
 }
 h1 {
-  font-size: 24.624px;
-  line-height: 29.548799999999996px;
+  font-size: 1.6em;
+  line-height: 1.2;
 }
 h2 {
-  font-size: 24.624px;
-  line-height: 29.548799999999996px;
+  font-size: 1.6em;
+  line-height: 1.2;
 }
 h3 {
-  font-size: 23.44px;
-  line-height: 28.128px;
+  font-size: 1.45em;
+  line-height: 1.2;
 }
 h4 {
-  font-size: 22.16px;
-  line-height: 26.592px;
+  font-size: 1.38em;
+  line-height: 1.2;
 }
 h5 {
-  font-size: 22.16px;
-  line-height: 26.592px;
+  font-size: 1.38em;
+  line-height: 1.2;
 }
 h6 {
-  font-size: 22.16px;
-  line-height: 26.592px;
+  font-size: 1.38em;
+  line-height: 1.2;
 }
 img {
-  margin-bottom: 20px;
+  margin-bottom: 1.25em;
 }
 h1 img,
 h2 img,
@@ -96,27 +96,27 @@ p img {
   margin-bottom: 0;
 }
 pre {
-  margin-bottom: 20px;
+  margin-bottom: 1.25em;
 }
 pre,
 code {
-  font-family: "Source Code Pro", Monokai, Consolas, Inconsolata,  Courier, monospace;
+  font-family: monospace;
 }
 pre {
   white-space: pre;
   white-space: pre-wrap;
   word-wrap: break-word;
-  padding: 15px;
+  padding: 0.95em;
 }
 blockquote {
   border-left: 4px solid;
-  padding: 0 15px;
+  padding: 0 0.95em;
 }
 blockquote > :first-child {
   margin-top: 0;
 }
 blockquote > :last-child {
-  margin-bottom: 15px;
+  margin-bottom: 0.95em;
 }
 h1 {
   text-transform: uppercase;

--- a/app/styles/solarized-light.css
+++ b/app/styles/solarized-light.css
@@ -19,9 +19,9 @@ img {
   vertical-align: baseline;
 }
 html * {
-  font-family: "ff-din-web-pro-1", "ff-din-web-pro-2", sans-serif;
-  font-size: 16px;
-  line-height: 19.2px;
+  font-family: sans-serif;
+  font-size: 1em;
+  line-height: 1.2;
   color-profile: sRGB;
 }
 body {
@@ -29,7 +29,7 @@ body {
 }
 p {
   font-weight: lighter;
-  margin-bottom: 20px;
+  margin-bottom: 0.8em;
 }
 strong {
   font-weight: bold;
@@ -37,16 +37,16 @@ strong {
 ol,
 ul {
   margin-left: 2em;
-  margin-bottom: 20px;
+  margin-bottom: 0.6em;
 }
 ul ul,
 ol ol,
 ul ol,
 ol ul {
-  margin-top: 10px;
+  margin-top: 0.3em;
 }
 li {
-  margin-bottom: 10px;
+  margin-bottom: 0.3em;
 }
 h1,
 h2,
@@ -56,35 +56,35 @@ h5,
 h6 {
   font-weight: lighter;
   text-transform: capitalize;
-  margin-top: 40px;
-  margin-bottom: 20px;
+  margin-top: 0.7em;
+  margin-bottom: 0.35em;
 }
 h1 {
-  font-size: 24.624px;
-  line-height: 29.548799999999996px;
+  font-size: 1.6em;
+  line-height: 1.2;
 }
 h2 {
-  font-size: 24.624px;
-  line-height: 29.548799999999996px;
+  font-size: 1.6em;
+  line-height: 1.2;
 }
 h3 {
-  font-size: 23.44px;
-  line-height: 28.128px;
+  font-size: 1.45em;
+  line-height: 1.2;
 }
 h4 {
-  font-size: 22.16px;
-  line-height: 26.592px;
+  font-size: 1.38em;
+  line-height: 1.2;
 }
 h5 {
-  font-size: 22.16px;
-  line-height: 26.592px;
+  font-size: 1.38em;
+  line-height: 1.2;
 }
 h6 {
-  font-size: 22.16px;
-  line-height: 26.592px;
+  font-size: 1.38em;
+  line-height: 1.2;
 }
 img {
-  margin-bottom: 20px;
+  margin-bottom: 1.25em;
 }
 h1 img,
 h2 img,
@@ -96,27 +96,27 @@ p img {
   margin-bottom: 0;
 }
 pre {
-  margin-bottom: 20px;
+  margin-bottom: 1.25em;
 }
 pre,
 code {
-  font-family: "Source Code Pro", Monokai, Consolas, Inconsolata,  Courier, monospace;
+  font-family: monospace;
 }
 pre {
   white-space: pre;
   white-space: pre-wrap;
   word-wrap: break-word;
-  padding: 15px;
+  padding: 0.95em;
 }
 blockquote {
   border-left: 4px solid;
-  padding: 0 15px;
+  padding: 0 0.95em;
 }
 blockquote > :first-child {
   margin-top: 0;
 }
 blockquote > :last-child {
-  margin-bottom: 15px;
+  margin-bottom: 0.95em;
 }
 h1 {
   text-transform: uppercase;


### PR DESCRIPTION
Font sizes and families were hardcoded in CSS files before. Let's fix them and make them respect configured font families and
sizes in settings.

Also, Qt doesn't allow single quotation marks in CSS files (why?). This made markdown.css fail to load. Let's fix that.