### PR TITLE
update mathjax to recommended cdnjs CDN provider

### DIFF
--- a/app-static/template/htmltemplate.cpp
+++ b/app-static/template/htmltemplate.cpp
@@ -111,7 +111,7 @@ QString HtmlTemplate::buildHtmlHeader(RenderOptions options) const
             header += QLatin1String("<script type=\"text/x-mathjax-config\">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\\\(','\\\\)']]}});</script>");
         }
 
-        header += QLatin1String("<script type=\"text/javascript\" src=\"http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML\"></script>\n");
+        header += QLatin1String("<script type=\"text/javascript\" src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-AMS-MML_HTMLorMML\"></script>\n");
     }
 
     // add Highlight.js script to HTML header

--- a/app/template_presentation.html
+++ b/app/template_presentation.html
@@ -28,7 +28,7 @@
 <script>
 Reveal.initialize({
     math: {
-        mathjax: 'https://cdn.mathjax.org/mathjax/latest/MathJax.js',
+        mathjax: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js',
         config: 'TeX-AMS_HTML-full'  // See http://docs.mathjax.org/en/latest/config-files.html
     },
 


### PR DESCRIPTION
correct the following navigator warning :
> WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.